### PR TITLE
Updating internal models from new breaking strava api response

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -20,9 +20,7 @@ export class AppComponent{
   openFeedbackDialog(): void {
     const dialogRef = this.dialog.open(FeedbackDialogComponent);
 
-    dialogRef.afterClosed().subscribe(result => {
-      console.log('App Component: The dialog was closed');
-    });
+    dialogRef.afterClosed().subscribe(result => {});
   }
 
   showStravaDialog(): void {

--- a/src/app/core/cookie-service/cookie-service.service.ts
+++ b/src/app/core/cookie-service/cookie-service.service.ts
@@ -8,8 +8,8 @@ export class CookieService {
 
   constructor(private ngxCookieService: NgxCookieService) { }
 
-  write (cookie_name: string, cookie_value: string) {
-    this.ngxCookieService.set(cookie_name,cookie_value);
+  write (cookie_name: string, cookie_value: string, cookie_expiry?: Date | number) {
+    this.ngxCookieService.set(cookie_name,cookie_value, cookie_expiry);
   }
 
   check_exists (cookie_name: string) {

--- a/src/app/core/strava-service/strava.service.ts
+++ b/src/app/core/strava-service/strava.service.ts
@@ -100,7 +100,7 @@ export class StravaService {
       );
 
       // save oauth refresh token in local browser cookies
-      this.cookieService.write('oauth_refresh_token', this.refresh_token);
+      this.cookieService.write('oauth_refresh_token', this.refresh_token, 365);
   }
 
   oauth_url(): string {

--- a/src/app/core/strava-service/strava.service.ts
+++ b/src/app/core/strava-service/strava.service.ts
@@ -33,7 +33,6 @@ export class StravaService {
     var response: any[];
 
     do{
-      console.log(`getting page ${pagenumber}`)
       response = await this.getActivities(this.access_token, pagenumber)
       activities.push(...response)
       pagenumber++;
@@ -69,14 +68,12 @@ export class StravaService {
   }
 
   async update_tokens(): Promise<void> {
-    console.log('updating token')
     await this.oauth_token_request({
       client_id: this._client_id,
       client_secret: this._client_secret,
       grant_type: "refresh_token",
       refresh_token: this.refresh_token
     });
-    console.log('token updated')
   }
 
   async get_access_token(): Promise<void> {

--- a/src/app/features/dialogs/feedback-dialog/feedback-dialog.component.ts
+++ b/src/app/features/dialogs/feedback-dialog/feedback-dialog.component.ts
@@ -36,9 +36,7 @@ export class FeedbackDialogComponent {
         this.feedbackForm,
         { 'headers': headers }
       ).subscribe(
-        response => {
-          console.log(response);
-        }
+        response => {}
       );
 
       // give user confirmation

--- a/src/app/features/map-page/map-page.component.ts
+++ b/src/app/features/map-page/map-page.component.ts
@@ -37,8 +37,9 @@ export class MapPageComponent implements OnInit {
   }
 
   async loadAndPlot(){
-    await this.MakeApiCall();
+    let loadingDialogRef = await this.MakeApiCall();
     this.PlotResults();
+    loadingDialogRef.close();
   }
 
   activities: SummaryActivity[] = [];
@@ -47,7 +48,7 @@ export class MapPageComponent implements OnInit {
     const dialogRef = this.dialog.open(SpinnerDialog);
     let response = await this.stravaService.getAllActivities()
     this.activities = response;
-    dialogRef.close();
+    return dialogRef
   }
 
   PlotResults(){

--- a/src/app/features/map-page/map-page.component.ts
+++ b/src/app/features/map-page/map-page.component.ts
@@ -63,7 +63,7 @@ export class MapPageComponent implements OnInit {
     for (var activity of this.activities.reverse()){
 
       // skip activities without a polyline
-      if (activity.map.summary_polyline == null){
+      if (activity.map == null){
         continue
       }
 


### PR DESCRIPTION
An activity with no map will now respond with a 'map' property of null, instead of containing a polyline item that was null.
Other improvements include cookie fixing, and aesthetic improvements